### PR TITLE
Change tokens as a environment variables defined in production

### DIFF
--- a/src/main/java/net/mossol/MossolLineController.java
+++ b/src/main/java/net/mossol/MossolLineController.java
@@ -12,6 +12,7 @@ import net.mossol.util.MessageBuildUtil;
 import org.apache.tomcat.util.codec.binary.Base64;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.Resource;
@@ -26,7 +27,9 @@ import java.util.concurrent.atomic.AtomicLong;
 public class MossolLineController {
     private static final Logger logger = LoggerFactory.getLogger(MossolLineController.class);
     private static final String template = "%dth, Hello, %s!";
-    private static final String SECRET_KEY = "49588e53b2c64f47a3fc84739e17b757";
+
+    @Value("${lineSecret}")
+    private String SECRET_KEY;
 
     private final AtomicLong counter = new AtomicLong();
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 # slack integrations
 rtmUrl=https://slack.com/api/rtm.start?token={token}&simple_latest&no_unreads
-slackBotToken=xoxb-299301845248-390549825744-9VbtpryfNx1bIz1FIOMsDEcb
+slackBotToken=<defined as environment variable in the production machine>
 slackApi=https://slack.com/api
 logging.level.me.ramswaroop=DEBUG
 server.port=8181
+
+# line integration
+lineSecret=<defined as environment variable in the production machine>


### PR DESCRIPTION
- Change slack token & bot secret as a environment variables
- Previous tokens are invalid now